### PR TITLE
Add automatic deployment capability to release workflow

### DIFF
--- a/.github/workflows/cd-ansible-deploy.yaml
+++ b/.github/workflows/cd-ansible-deploy.yaml
@@ -28,6 +28,8 @@ on:
         description: 'Version tag to deploy (e.g. v1.0.99, include v prefix)'
         required: false
         type: string
+  repository_dispatch:
+    types: [deploy-release]
 
 jobs:
   # ======================================
@@ -36,7 +38,7 @@ jobs:
   validate-tag:
     name: Validate Tag Exists
     runs-on: ubuntu-latest
-    if: github.event.inputs.version_tag != ''
+    if: github.event.inputs.version_tag != '' || github.event.client_payload.version_tag != ''
     outputs:
       tag_exists: ${{ steps.check-tag.outputs.tag_exists }}
     steps:
@@ -48,7 +50,13 @@ jobs:
       - name: Check if tag exists
         id: check-tag
         run: |
-          TAG="${{  github.event.inputs.version_tag  }}"
+          # Get the tag from inputs or client payload
+          if [ -n "${{ github.event.inputs.version_tag }}" ]; then
+            TAG="${{ github.event.inputs.version_tag }}"
+          else
+            TAG="${{ github.event.client_payload.version_tag }}"
+          fi
+
           echo "🔍 Checking if tag \"$TAG\" exists in the repository..."
 
           if git tag -l | grep -q "^$TAG$"; then
@@ -66,7 +74,7 @@ jobs:
   ansible-deployment:
     name: Run Ansible Deployment
     needs: validate-tag
-    if: github.event.inputs.version_tag == '' || needs.validate-tag.outputs.tag_exists == 'true'
+    if: github.event.inputs.version_tag == '' || github.event.client_payload.version_tag == '' || needs.validate-tag.outputs.tag_exists == 'true'
     runs-on: self-hosted
 
     steps:
@@ -120,7 +128,7 @@ jobs:
           chmod 700 ~/.ssh
 
           # Write the SSH private key
-          echo "${{  secrets.SSH_PRIVATE_KEY  }}" > ~/.ssh/id_ed25519
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
           # Extract hosts from inventory file and add to known_hosts
@@ -159,20 +167,45 @@ jobs:
           fi
 
           # Set up deployment variables
-          DEPLOYMENT_TYPE="${{  github.event.inputs.deployment_type  }}"
+          # Get deployment type from inputs or client payload
+          if [ -n "${{ github.event.inputs.deployment_type }}" ]; then
+            DEPLOYMENT_TYPE="${{ github.event.inputs.deployment_type }}"
+          else
+            DEPLOYMENT_TYPE="${{ github.event.client_payload.deployment_type }}"
+          fi
+
           EXTRA_VARS=""
 
           # Version tag handling
-          if [ -n "${{  github.event.inputs.version_tag  }}" ]; then
-            VERSION_TAG="${{  github.event.inputs.version_tag  }}"
+          # Get version tag from inputs or client payload
+          if [ -n "${{ github.event.inputs.version_tag }}" ]; then
+            VERSION_TAG="${{ github.event.inputs.version_tag }}"
+          elif [ -n "${{ github.event.client_payload.version_tag }}" ]; then
+            VERSION_TAG="${{ github.event.client_payload.version_tag }}"
+          fi
+
+          if [ -n "$VERSION_TAG" ]; then
             VERSION_NUMBER="${VERSION_TAG#v}"
             echo "📌 Using version tag: \"$VERSION_TAG\" (\"$VERSION_NUMBER\")"
             EXTRA_VARS="api_release_version=\"$VERSION_NUMBER\" frontend_release_version=\"$VERSION_NUMBER\""
           fi
 
-          # Build the tags parameter based on deployment type
-          DEPLOYMENT_TYPE="${{  github.event.inputs.deployment_type  }}"
+          # Additional component-specific version handling for repository_dispatch
+          if [ -n "${{ github.event.client_payload.api_version }}" ]; then
+            API_VERSION="${{ github.event.client_payload.api_version }}"
+            API_VERSION_NUMBER="${API_VERSION#v}"
+            echo "📌 Using custom API version: \"$API_VERSION\" (\"$API_VERSION_NUMBER\")"
+            EXTRA_VARS="$EXTRA_VARS api_release_version=\"$API_VERSION_NUMBER\""
+          fi
 
+          if [ -n "${{ github.event.client_payload.frontend_version }}" ]; then
+            FRONTEND_VERSION="${{ github.event.client_payload.frontend_version }}"
+            FRONTEND_VERSION_NUMBER="${FRONTEND_VERSION#v}"
+            echo "📌 Using custom Frontend version: \"$FRONTEND_VERSION\" (\"$FRONTEND_VERSION_NUMBER\")"
+            EXTRA_VARS="$EXTRA_VARS frontend_release_version=\"$FRONTEND_VERSION_NUMBER\""
+          fi
+
+          # Build the tags parameter based on deployment type
           # Extract clean tag name from deployment type (remove "ansible-" prefix)
           if [ "$DEPLOYMENT_TYPE" = "ansible-deploy" ]; then
             # Full deployment doesn't use tags
@@ -203,11 +236,11 @@ jobs:
           echo "🎯 Deploying component: \"$COMPONENT\""
 
           # Set up additional extra vars and run the deployment
-          ALL_EXTRA_VARS="github_token=\"?$GITHUB_TOKEN"?\" ansible_user=ubuntu $EXTRA_VARS"
+          ALL_EXTRA_VARS="github_token=\"$GITHUB_TOKEN\" ansible_user=ubuntu $EXTRA_VARS"
 
           echo "🔧 Running make \"$DEPLOYMENT_TYPE\" with the following parameters:"
-          echo "   → Extra vars: github_token=*** ${EXTRA_VARS##*( )}"
-          echo "   → Tags: ${TAG_PARAM##*( )}"
+          echo "   → Extra vars: github_token=*** ${EXTRA_VARS}"
+          echo "   → Tags: ${TAG_PARAM}"
 
           make "$DEPLOYMENT_TYPE" ANSIBLE_EXTRA_VARS="$ALL_EXTRA_VARS"
 
@@ -218,23 +251,46 @@ jobs:
       # --------------------------------
       - name: Deployment summary
         run: |
+          # Get deployment type from inputs or client payload
+          if [ -n "${{ github.event.inputs.deployment_type }}" ]; then
+            DEPLOYMENT_TYPE="${{ github.event.inputs.deployment_type }}"
+          else
+            DEPLOYMENT_TYPE="${{ github.event.client_payload.deployment_type }}"
+          fi
+
+          # Get version tag from inputs or client payload
+          if [ -n "${{ github.event.inputs.version_tag }}" ]; then
+            VERSION_TAG="${{ github.event.inputs.version_tag }}"
+          elif [ -n "${{ github.event.client_payload.version_tag }}" ]; then
+            VERSION_TAG="${{ github.event.client_payload.version_tag }}"
+          fi
+
           {
             echo "## 📋 Deployment Summary"
             echo "### 🛠️ Deployment Configuration"
             echo "| Setting | Value |"
             echo "| --- | --- |"
-            echo "| ⚙️ **Deployment type** | ${{  github.event.inputs.deployment_type  }} |"
+            echo "| ⚙️ **Deployment type** | $DEPLOYMENT_TYPE |"
             echo "| 🔐 **Authentication method** | SSH key |"
             echo "| 👤 **User** | ubuntu |"
             echo "| 🖥️ **Target servers** | Using inventory file |"
 
-            if [ -n "${{  github.event.inputs.version_tag  }}" ]; then
-              echo "| 📦 **Version Tag** | ${{  github.event.inputs.version_tag  }} |"
+            if [ -n "$VERSION_TAG" ]; then
+              echo "| 📦 **Version Tag** | $VERSION_TAG |"
+            fi
+
+            # Display component-specific versions if set
+            if [ -n "${{ github.event.client_payload.api_version }}" ]; then
+              echo "| 🖥️ **API Version** | ${{ github.event.client_payload.api_version }} |"
+            fi
+
+            if [ -n "${{ github.event.client_payload.frontend_version }}" ]; then
+              echo "| 🌐 **Frontend Version** | ${{ github.event.client_payload.frontend_version }} |"
             fi
 
             echo "### 📊 Deployment Status"
 
-            case "${{  github.event.inputs.deployment_type  }}" in
+            case "$DEPLOYMENT_TYPE" in
               ansible-deploy)
                 echo "✅ **Full Ansible playbook executed**"
                 ;;

--- a/.github/workflows/cd-release-automation.yaml
+++ b/.github/workflows/cd-release-automation.yaml
@@ -1,5 +1,5 @@
 name: Release Automation
-run-name: Release Process ${{ github.event.inputs.release_type != '' && format('({0})', github.event.inputs.release_type) || '(auto)' }}
+run-name: Release Process ${{ github.event.inputs.release_type != '' && format('({0})', github.event.inputs.release_type) || '(auto)' }}${{ github.event.inputs.deploy_after_release == 'true' && ' + Deploy' || '' }}
 
 permissions:
   contents: write
@@ -21,6 +21,31 @@ on:
           - patch
           - minor
           - major
+      deploy_after_release:
+        description: 'Deploy after release creation'
+        required: false
+        default: false
+        type: boolean
+      deployment_type:
+        description: 'Ansible deployment type (if deploying)'
+        required: false
+        default: 'ansible-deploy'
+        type: choice
+        options:
+          - ansible-deploy
+          - ansible-api
+          - ansible-frontend
+          - ansible-nginx
+          - ansible-logging
+          - ansible-security
+      api_tag:
+        description: 'Custom API tag (overrides auto-versioning, include v prefix)'
+        required: false
+        type: string
+      frontend_tag:
+        description: 'Custom Frontend tag (overrides auto-versioning, include v prefix)'
+        required: false
+        type: string
 
 jobs:
   analyze-commits:
@@ -257,8 +282,14 @@ jobs:
     steps:
       - name: Setup GitHub CLI
         run: |
-          # Authenticate GitHub CLI with the workflow token
-          echo "${{ github.token }}" | gh auth login --with-token
+          # Install GitHub CLI
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          sudo apt install gh -y
+
+          # Authenticate with GitHub token
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Wait for builds to complete with polling
         run: |
@@ -507,6 +538,14 @@ jobs:
           # Run with docker-compose
           docker-compose -f docker-compose.yml up -d
           \`\`\`
+
+          ## Deployment Options
+
+          ### Automatic Deployment
+          You can enable automatic deployment when creating a release by setting the \`deploy_after_release\` option to \`true\`.
+
+          ### Manual Deployment
+          To deploy manually after release, run the Ansible deployment workflow with the version tag \`${{ needs.bump-version.outputs.new_tag }}\`.
           EOF
 
       - name: Create Release ${{ needs.bump-version.outputs.new_tag }}
@@ -581,5 +620,142 @@ jobs:
           echo "| **Total** | $TOTAL_COUNT | |" >> $GITHUB_STEP_SUMMARY
 
           echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
-          echo "To deploy this release, run the Ansible deployment workflow with:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version tag**: ${{ needs.bump-version.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ github.event.inputs.deploy_after_release }}" == "true" ]; then
+            echo "✅ **Automatic deployment enabled.** The Ansible deployment workflow will be triggered automatically." >> $GITHUB_STEP_SUMMARY
+            echo "- Deployment type: ${{ github.event.inputs.deployment_type || 'ansible-deploy (full deployment)' }}" >> $GITHUB_STEP_SUMMARY
+
+            if [ -n "${{ github.event.inputs.api_tag }}" ] || [ -n "${{ github.event.inputs.frontend_tag }}" ]; then
+              echo "- Using custom component tags:" >> $GITHUB_STEP_SUMMARY
+
+              if [ -n "${{ github.event.inputs.api_tag }}" ]; then
+                echo "  - API: ${{ github.event.inputs.api_tag }}" >> $GITHUB_STEP_SUMMARY
+              fi
+
+              if [ -n "${{ github.event.inputs.frontend_tag }}" ]; then
+                echo "  - Frontend: ${{ github.event.inputs.frontend_tag }}" >> $GITHUB_STEP_SUMMARY
+              fi
+            else
+              echo "- Using release tag: ${{ needs.bump-version.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "To deploy this release manually, run the Ansible deployment workflow with:" >> $GITHUB_STEP_SUMMARY
+            echo "- **Version tag**: ${{ needs.bump-version.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ==============================================================
+  # Deployment Job - Only runs if deploy_after_release is enabled
+  # ==============================================================
+  deploy-release:
+    name: Deploy Release with Ansible
+    needs: [bump-version, create-release]
+    if: ${{ github.event.inputs.deploy_after_release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup GitHub CLI
+        run: |
+          # Install GitHub CLI
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          sudo apt install gh -y
+
+          # Authenticate with GitHub token
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Trigger Ansible Deployment Workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🚀 Starting deployment process..."
+
+          # Determine which tags to use
+          API_TAG="${{ github.event.inputs.api_tag }}"
+          FRONTEND_TAG="${{ github.event.inputs.frontend_tag }}"
+          DEFAULT_TAG="${{ needs.bump-version.outputs.new_tag }}"
+          DEPLOYMENT_TYPE="${{ github.event.inputs.deployment_type }}"
+
+          # If custom tags are not provided, use the default tag
+          [ -z "$API_TAG" ] && API_TAG="$DEFAULT_TAG"
+          [ -z "$FRONTEND_TAG" ] && FRONTEND_TAG="$DEFAULT_TAG"
+
+          echo "Using the following configuration:"
+          echo "- Deployment type: $DEPLOYMENT_TYPE"
+          echo "- API tag: $API_TAG"
+          echo "- Frontend tag: $FRONTEND_TAG"
+
+          # Set version tag based on deployment type
+          if [[ "$DEPLOYMENT_TYPE" == "ansible-api" ]]; then
+            VERSION_TAG="$API_TAG"
+            echo "Setting version tag to API tag: $VERSION_TAG"
+          elif [[ "$DEPLOYMENT_TYPE" == "ansible-frontend" ]]; then
+            VERSION_TAG="$FRONTEND_TAG"
+            echo "Setting version tag to Frontend tag: $VERSION_TAG"
+          else
+            # For full deployment or other components, use the default tag
+            VERSION_TAG="$DEFAULT_TAG"
+            echo "Setting version tag to default tag: $VERSION_TAG"
+          fi
+
+          # Trigger the deployment workflow
+          echo "Triggering Ansible deployment workflow..."
+          gh workflow run cd-ansible-deploy.yaml \
+            -f deployment_type="$DEPLOYMENT_TYPE" \
+            -f version_tag="$VERSION_TAG"
+
+          echo "✅ Deployment workflow triggered successfully"
+          echo "📊 Deployment details:"
+          echo "   → Type: $DEPLOYMENT_TYPE"
+          echo "   → Version: $VERSION_TAG"
+
+      - name: Generate deployment summary
+        run: |
+          # Determine deployment type name
+          DEPLOYMENT_TYPE="${{ github.event.inputs.deployment_type }}"
+          case "$DEPLOYMENT_TYPE" in
+            ansible-deploy)
+              COMPONENT="Full Infrastructure"
+              ;;
+            ansible-api)
+              COMPONENT="API Service"
+              ;;
+            ansible-frontend)
+              COMPONENT="Frontend Application"
+              ;;
+            ansible-nginx)
+              COMPONENT="Nginx"
+              ;;
+            ansible-logging)
+              COMPONENT="Logging Stack"
+              ;;
+            ansible-security)
+              COMPONENT="Security Settings"
+              ;;
+            *)
+              COMPONENT="Unknown Component"
+              ;;
+          esac
+
+          # Create summary
+          echo "## 🚀 Deployment Triggered" >> $GITHUB_STEP_SUMMARY
+          echo "### 📊 Deployment Information" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🎯 **Component** | $COMPONENT |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🏷️ **Release Version** | ${{ needs.bump-version.outputs.new_tag }} |" >> $GITHUB_STEP_SUMMARY
+
+          # Add custom tag information if provided
+          if [ -n "${{ github.event.inputs.api_tag }}" ]; then
+            echo "| 🖥️ **API Tag** | ${{ github.event.inputs.api_tag }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ -n "${{ github.event.inputs.frontend_tag }}" ]; then
+            echo "| 🌐 **Frontend Tag** | ${{ github.event.inputs.frontend_tag }} |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "### 📝 Deployment Status" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Ansible deployment workflow triggered successfully" >> $GITHUB_STEP_SUMMARY
+          echo "📊 You can monitor the deployment progress in the Actions tab" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cd-release-automation.yaml
+++ b/.github/workflows/cd-release-automation.yaml
@@ -655,61 +655,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup GitHub CLI
-        run: |
-          # Install GitHub CLI
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt update
-          sudo apt install gh -y
-
-          # Authenticate with GitHub token
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
-      - name: Trigger Ansible Deployment Workflow
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "🚀 Starting deployment process..."
-
-          # Determine which tags to use
-          API_TAG="${{ github.event.inputs.api_tag }}"
-          FRONTEND_TAG="${{ github.event.inputs.frontend_tag }}"
-          DEFAULT_TAG="${{ needs.bump-version.outputs.new_tag }}"
-          DEPLOYMENT_TYPE="${{ github.event.inputs.deployment_type }}"
-
-          # If custom tags are not provided, use the default tag
-          [ -z "$API_TAG" ] && API_TAG="$DEFAULT_TAG"
-          [ -z "$FRONTEND_TAG" ] && FRONTEND_TAG="$DEFAULT_TAG"
-
-          echo "Using the following configuration:"
-          echo "- Deployment type: $DEPLOYMENT_TYPE"
-          echo "- API tag: $API_TAG"
-          echo "- Frontend tag: $FRONTEND_TAG"
-
-          # Set version tag based on deployment type
-          if [[ "$DEPLOYMENT_TYPE" == "ansible-api" ]]; then
-            VERSION_TAG="$API_TAG"
-            echo "Setting version tag to API tag: $VERSION_TAG"
-          elif [[ "$DEPLOYMENT_TYPE" == "ansible-frontend" ]]; then
-            VERSION_TAG="$FRONTEND_TAG"
-            echo "Setting version tag to Frontend tag: $VERSION_TAG"
-          else
-            # For full deployment or other components, use the default tag
-            VERSION_TAG="$DEFAULT_TAG"
-            echo "Setting version tag to default tag: $VERSION_TAG"
-          fi
-
-          # Trigger the deployment workflow
-          echo "Triggering Ansible deployment workflow..."
-          gh workflow run cd-ansible-deploy.yaml \
-            -f deployment_type="$DEPLOYMENT_TYPE" \
-            -f version_tag="$VERSION_TAG"
-
-          echo "✅ Deployment workflow triggered successfully"
-          echo "📊 Deployment details:"
-          echo "   → Type: $DEPLOYMENT_TYPE"
-          echo "   → Version: $VERSION_TAG"
+      - name: Trigger Ansible Deployment
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: deploy-release
+          client-payload: |
+            {
+              "deployment_type": "${{ github.event.inputs.deployment_type }}",
+              "version_tag": "${{ needs.bump-version.outputs.new_tag }}",
+              "api_version": "${{ github.event.inputs.api_tag || needs.bump-version.outputs.new_tag }}",
+              "frontend_version": "${{ github.event.inputs.frontend_tag || needs.bump-version.outputs.new_tag }}",
+              "triggered_by": "release-automation"
+            }
 
       - name: Generate deployment summary
         run: |


### PR DESCRIPTION
This PR adds the ability to automatically deploy after a release is created. It adds deploy_after_release, deployment_type, api_tag and frontend_tag options to make the release process smoother by eliminating manual deployment steps.