### PR TITLE
Add package.json to frontend bundle

### DIFF
--- a/.github/workflows/cd-build-frontend.yaml
+++ b/.github/workflows/cd-build-frontend.yaml
@@ -118,8 +118,15 @@ jobs:
       - name: Create archive
         run: |
           cd frontend
-          # Create the tar.gz bundle using the dist directory
-          tar -czf ../frontend-bundle.tar.gz dist
+          # Create a temporary directory for bundling
+          mkdir -p bundle
+
+          # Copy dist directory and package.json to the bundle directory
+          cp -r dist bundle/
+          cp package.json bundle/
+
+          # Create the tar.gz bundle using the bundle directory
+          tar -czf ../frontend-bundle.tar.gz -C bundle .
 
           # Create artifacts directory
           mkdir -p ../artifacts
@@ -197,12 +204,12 @@ jobs:
             | 🔄 **Workflow Run** | [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
 
             ### 📦 Included Artifacts
-            - **🌐 Frontend Bundle**: `frontend-bundle.tar.gz`
+            - **🌐 Frontend Bundle**: `frontend-bundle.tar.gz` (includes dist/ and package.json)
 
             ### 📝 Deployment Instructions
             1. Download the frontend bundle
             2. Extract the contents: `tar -xzf frontend-bundle.tar.gz`
-            3. Deploy the extracted `dist` folder to your web server
+            3. Deploy the extracted files to your web server
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Purpose
This PR modifies the frontend build workflow to include `package.json` in the frontend bundle alongside the built assets.

## Changes
- Updated the archive creation step in `.github/workflows/cd-build-frontend.yaml` to:
  - Create a temporary bundle directory
  - Copy both the `dist` directory and `package.json` into it
  - Create the tarball from the contents of this bundle directory
- Updated the release notes to reflect the inclusion of package.json
- Updated the deployment instructions accordingly

## Benefits
- Having package.json available in the deployed frontend allows for:
  - Access to metadata like version, name, and description
  - Simplified dependency management if the server needs to reference it
  - Ability to run any defined scripts directly from the deployment directory

## Testing
The changes don't affect the build process itself, only what's included in the final archive. The next frontend build will include the package.json file automatically.